### PR TITLE
Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.env


### PR DESCRIPTION
## This PR

- Adds `.env` to `.gitignore`

## Why

- Project environment variable values may differ between developer workstations, so it isn't something we want to check-in to our remote repository