### PR TITLE
Set application time zone based on browser time zone

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,21 @@
 
 class ApplicationController < ActionController::Base
   include Clearance::Controller
+
+  before_action :set_time_zone
+
+  def set_time_zone
+    Time.zone = browser_time_zone
+  end
+
+  private
+
+  def browser_time_zone
+    browser_tz = ActiveSupport::TimeZone.find_tzinfo(cookies[:timezone])
+    ActiveSupport::TimeZone
+      .all
+      .find { |zone| zone.tzinfo == browser_tz } || Time.zone
+  rescue TZInfo::UnknownTimezone, TZInfo::InvalidTimezoneIdentifier
+    Time.zone
+  end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,7 +8,6 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 
-
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.

--- a/app/javascript/packs/timezone.js
+++ b/app/javascript/packs/timezone.js
@@ -1,0 +1,12 @@
+import jstz from 'jstz'
+
+const setCookie = (name, value) => {
+  let expires = new Date()
+  expires.setTime(expires.getTime() + (24 * 60 * 60 * 1000))
+  document.cookie = name + '=' + value + ';expires=' + expires.toUTCString()
+}
+
+document.addEventListener("turbolinks:load", () => {
+  const timezone = jstz.determine()
+  setCookie("timezone", timezone.name())
+})

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "application", media: "all", 'data-turbolinks-track': "reload" %>
     <%= javascript_pack_tag "application", 'data-turbolinks-track': "reload" %>
+    <%= javascript_pack_tag "timezone", 'data-turbolinks-track': "reload" %>
   </head>
   <body>
     <% if signed_in? %>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
+    "jstz": "^2.1.1",
     "minimist": "^1.2.2",
     "stimulus": "^1.1.1",
     "turbolinks": "^5.2.0"

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ApplicationController do
+  controller do
+    def test_tz_cookie
+      head :ok
+    end
+  end
+
+  before do
+    routes.draw { get "test_tz_cookie" => "anonymous#test_tz_cookie" }
+  end
+
+  it "sets the application's time zone to the browser time zone" do
+    cookies[:timezone] = "America/New_York"
+
+    get :test_tz_cookie
+
+    Time.zone.name == "Eastern Time (US & Canada)"
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -3933,6 +3933,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jstz@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/jstz/-/jstz-2.1.1.tgz#fff3373a518fa7cce69299930466f5a2b980389d"
+  integrity sha512-8hfl5RD6P7rEeIbzStBz3h4f+BQHfq/ABtoU6gXKQv5OcZhnmrIpG7e1pYaZ8hS9e0mp+bxUj08fnDUbKctYyA==
+
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"


### PR DESCRIPTION
Closes #4

This commit adds jstz to grab the time zone from the user's browser. A
`timezone` cookie is set with the time zone found by jstz. Once per
request, the application time zone is set on each request from the
`timezone` cookie.