### PR TITLE
Fix inconsistent date time display

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -35,7 +35,7 @@ class GroupsController < ApplicationController
   def update
     @group = current_user.groups.find(params[:id])
 
-    if @group.update
+    if @group.update(group_params)
       redirect_to group_path(@group)
     else
       render :edit

--- a/app/models/call_page.rb
+++ b/app/models/call_page.rb
@@ -59,7 +59,7 @@ class CallPage
   attr_reader :viewer
 
   def call_date_text
-    DateFormatter.month_day_time(call.scheduled_on)
+    DateTimeFormatter.month_day_time(call.scheduled_on)
   end
 
   def call_label

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -12,8 +12,9 @@ class Group < ApplicationRecord
                   :saturday]
 
   with_options presence: true do
-    validates :name
     validates :call_day
+    validates :call_time
+    validates :name
   end
 
   def self.call_day_options
@@ -52,9 +53,9 @@ class Group < ApplicationRecord
 
   def next_call_date
     if call_day_before_type_cast == Date.current.wday
-      Chronic.parse("next #{call_day}")
+      Chronic.parse("next #{call_day} at #{DateTimeFormatter.time(call_time)}")
     else
-      Chronic.parse("this #{call_day}")
+      Chronic.parse("this #{call_day} at #{DateTimeFormatter.time(call_time)}")
     end
   end
 end

--- a/app/services/date_time_formatter.rb
+++ b/app/services/date_time_formatter.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-class DateFormatter
+class DateTimeFormatter
   def self.month_day_time(datetime)
-    datetime.strftime("%A, %B %e at %l %p %Z")
+    datetime.strftime("%A, %B %e at %l:%M %p %Z")
   end
 
   def self.month_day(datetime)
@@ -10,11 +10,11 @@ class DateFormatter
   end
 
   def self.time_with_zone(datetime)
-    datetime.strftime("%l:%m %p %Z")
+    datetime.strftime("%l:%M %p %Z")
   end
 
   def self.time(datetime)
-    datetime.strftime("%l:%m %p")
+    datetime.strftime("%l:%M %p")
   end
 
   def self.small_month_day(datetime)

--- a/app/views/calls/edit.html.erb
+++ b/app/views/calls/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="centered-form">
   <h2>
-    Edit call on <%= DateFormatter.month_day(@call.scheduled_on) %>
+    Edit call on <%= DateTimeFormatter.month_day(@call.scheduled_on) %>
   </h2>
 
   <%= form_with model: @call do |form| %>

--- a/app/views/groups/_calls_section.html.erb
+++ b/app/views/groups/_calls_section.html.erb
@@ -9,13 +9,13 @@
           <div class="card-title"></div>
           <div class="card-content">
             <div class="day">
-              <%= DateFormatter.day(call.scheduled_on) %>
+              <%= DateTimeFormatter.day(call.scheduled_on) %>
             </div>
             <div class="month">
-              <%= DateFormatter.small_month_day(call.scheduled_on) %>
+              <%= DateTimeFormatter.small_month_day(call.scheduled_on) %>
             </div>
             <div class="time">
-              <%= DateFormatter.time(call.scheduled_on) %>
+              <%= DateTimeFormatter.time(call.scheduled_on) %>
             </div>
           </div>
           <div class="card-footer">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,13 +39,17 @@ group = Group.create!(name: 'Fellas', creator: anthony, call_time: '16:00')
 group.memberships.create!(user: anthony, role: Membership::FACILITATOR)
 group.users << [kurt, eric, tad, joe]
 
-last_call = group.calls.create!(scheduled_on: Date.current - 7.days)
-todays_call = group.calls.create!(scheduled_on: Date.current)
-group.calls.create!(scheduled_on: Date.current - 14.days)
+upcoming_call = group.upcoming_call
+todays_call = group
+  .calls
+  .create!(scheduled_on: upcoming_call.scheduled_on - 7.days)
+previous_call = group
+  .calls
+  .create!(scheduled_on: upcoming_call.scheduled_on - 14.days)
 
 group.memberships.each do |member|
   body = "#{member.user.first_name}'s commitment"
-  last_call.commitments.create!(membership: member, body: body)
+  previous_call.commitments.create!(membership: member, body: body)
 end
 
 Timer.create!(user: kurt, call: todays_call)

--- a/spec/services/date_time_formatter_spec.rb
+++ b/spec/services/date_time_formatter_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DateTimeFormatter do
+  describe "month_day_time" do
+    it "returns the datetime formatted as Saturday, April 4 at 3:31 PM UTC" do
+      datetime = Time.parse("2020-04-04 3:31PM UTC")
+      formatted_datetime = DateTimeFormatter.month_day_time(datetime)
+      expect(formatted_datetime) .to eq "Saturday, April  4 at  3:31 PM UTC"
+    end
+  end
+
+  describe "month_day" do
+    it "returns the datetime formatted as Saturday, April 4" do
+      datetime = Time.parse("2020-04-04 3:31PM UTC")
+      formatted_datetime = DateTimeFormatter.month_day(datetime)
+      expect(formatted_datetime) .to eq "Saturday, April  4"
+    end
+  end
+
+  describe "time" do
+    it "returns the time in 12-hour HH:MM AM/PM format" do
+      datetime = Time.parse("2020-04-04 3:31PM UTC")
+      formatted_datetime = DateTimeFormatter.time(datetime)
+      expect(formatted_datetime).to eq " 3:31 PM"
+    end
+  end
+
+  describe "time_with_zone" do
+    it "returns the time in 12-hour HH:MM AM/PM format with time zone" do
+      datetime = Time.parse("2020-04-04 3:31PM UTC")
+      formatted_datetime = DateTimeFormatter.time_with_zone(datetime)
+      expect(formatted_datetime).to eq " 3:31 PM UTC"
+    end
+  end
+
+  describe "small_month_day" do
+    it "returns abbreviated month plus day of the month" do
+      datetime = Time.parse("2020-04-04 3:31PM UTC")
+      formatted_datetime = DateTimeFormatter.small_month_day(datetime)
+      expect(formatted_datetime).to eq "Apr  4"
+    end
+  end
+
+  describe "day" do
+    it "returns the day of the week" do
+      datetime = Time.parse("2020-04-04 3:31PM UTC")
+      formatted_datetime = DateTimeFormatter.day(datetime)
+      expect(formatted_datetime).to eq "Saturday"
+    end
+  end
+end


### PR DESCRIPTION
Closes #16

This PR addresses two issues with the call times being displayed in a
few different places. Additionally, I refactored the DateFormatter to
DateTimeFormatter for a more accurate name.

Part of the issue was with the `strftime` calls being made in the
`DateTimeFormatter` using the wrong syntax.

Another issue was related to how calls were being created. The intention
was to use `Group#call_time` to set the `scheduled_on` attribute
of new calls, but the group attribute was never being used. This commit
fixes this issue as well.
