### PR TITLE
Prevent duplicate invites for existing memberships

### DIFF
--- a/app/models/group_invite.rb
+++ b/app/models/group_invite.rb
@@ -7,7 +7,15 @@ class GroupInvite < ApplicationRecord
 
   scope :unaccepted, -> { where(accepted: false) }
 
+  validate :user_not_already_in_group, on: :create
+
   private
+
+  def user_not_already_in_group
+    return unless group.users.where(email: email).exists?
+
+    errors.add(:group, "Can't send an invite to an existing member")
+  end
 
   def generate_token
     self.token = SecureRandom.hex

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -8,6 +8,8 @@ class Membership < ApplicationRecord
   MEMBER = "member"
   ROLES = [FACILITATOR, MEMBER].freeze
 
+  validates :user, uniqueness: { scope: :group }
+
   ROLES.each do |role|
     define_method "#{role}?" do
       self.role == role

--- a/app/services/group_inviter.rb
+++ b/app/services/group_inviter.rb
@@ -3,6 +3,8 @@
 class GroupInviter
   def self.perform(email, group, user)
     invite = GroupInvite.create(email: email, group: group)
-    GroupInviteMailer.invite(invite, user).deliver_now
+    if invite.valid?
+      GroupInviteMailer.invite(invite, user).deliver_now
+    end
   end
 end

--- a/spec/models/group_invite_spec.rb
+++ b/spec/models/group_invite_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe GroupInvite do
+  describe "validations" do
+    it "should validate the invitee is not already a member" do
+      membership = create(:membership)
+      user = membership.user
+      group = membership.group
+      invite = build(:group_invite, group: group, email: user.email)
+
+      expect(invite).to_not be_valid
+    end
+  end
+end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe Membership do
+  describe "validations" do
+    it "should validate that a user cannot have duplicate memberships" do
+      first_membership = create(:membership)
+      user = first_membership.user
+      group = first_membership.group
+
+      second_membership = user.memberships.create(group: group)
+
+      expect(second_membership).to_not be_valid
+    end
+  end
+end

--- a/spec/services/group_inviter_spec.rb
+++ b/spec/services/group_inviter_spec.rb
@@ -21,4 +21,25 @@ RSpec.describe GroupInviter do
 
     expect(GroupInviteMailer).to have_received(:invite)
   end
+
+  it "doesn't send an email if the invitee is the inviter" do
+    allow(GroupInviteMailer).to receive(:invite).and_call_original
+    membership = create(:membership)
+    group = membership.group
+    user = membership.user
+
+    GroupInviter.perform(user.email, group, user)
+
+    expect(GroupInviteMailer).to_not have_received(:invite)
+  end
+
+  it "doesn't create an invite if the invitee is the inviter" do
+    membership = create(:membership)
+    group = membership.group
+    user = membership.user
+
+    GroupInviter.perform(user.email, group, user)
+
+    expect(GroupInvite.where(email: user.email).exists?).to be false
+  end
 end


### PR DESCRIPTION
Closes #18

This PR fixes an issue where group invites were being sent to existing
members of a group. Upon accepting the invite, an additional membership
record was being created for that user. This caused the group to appear
twice in the user's group list.

This commit adds validations around the creation of memberships and
invites. Users will no longer receive invites for groups they belong to
and it is no longer possible to create multiple membership records for
the same user.