### PR TITLE
Fix intermittent spec failures

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -11,11 +11,20 @@ RSpec.describe ApplicationController do
     routes.draw { get "test_tz_cookie" => "anonymous#test_tz_cookie" }
   end
 
+  before do
+    allow(Time).to receive(:zone).and_call_original
+  end
+
+  after do
+    utc = ActiveSupport::TimeZone.all.detect { |tz| tz.name == "UTC" }
+    allow(Time).to receive(:zone).and_return(utc)
+  end
+
   it "sets the application's time zone to the browser time zone" do
     cookies[:timezone] = "America/New_York"
 
     get :test_tz_cookie
 
-    Time.zone.name == "Eastern Time (US & Canada)"
+    expect(Time.zone.name).to eq "Eastern Time (US & Canada)"
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,6 +23,11 @@ RSpec.configure do |config|
   config.before(:each, type: :system, js: true) do
     driven_by :selenium_chrome_headless
   end
+
+  config.before(:each) do
+    utc = ActiveSupport::TimeZone.all.detect { |tz| tz.name == "UTC" }
+    allow(Time).to receive(:zone).and_return(utc)
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This PR fixes an issue where tests would intermittently fail when the
local machines date differed from the UTC date. The failing tests' setup
phase was running in the default (UTC) timezone, but when the webdriver
executed the tests, the browser would set the timezone to the system's
timezone. This caused objects' timestamps to match tomorrows date
relative to the system's time instead of today's date.

The solution we arrived at was to stub out Time.zone to only return the
UTC timezone object before each test example. The only exception this is
in the ApplicationController test where we want to be able to test that
the application's timezone is indeed being set by the browser's time
zone.

Co-authored-by: Eric Hanko <eric.hanko1@gmail.com>