### PR TITLE
Ignore RubyMine-generated files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@
 yarn-debug.log*
 .yarn-integrity
 .env
+
+# Files and directories created by RubyMine IDE
+.generators
+.idea/
+.rakeTasks


### PR DESCRIPTION
This PR ignores files and directories that are automatically created by RubyMine, a JetBrains IDE for Ruby and Ruby on Rails development.