### PR TITLE
Fix a spelling error in "call" view HTML template

### DIFF
--- a/app/views/calls/_commitments.html.erb
+++ b/app/views/calls/_commitments.html.erb
@@ -34,7 +34,7 @@
     <% if show_form %>
       <div id="commitment_form">
         <div class="title">
-          I'm commiting to
+          I'm committing to
         </div>
         <%= form_with model: [@page.call, Commitment.new], remote: true do |form| %>
           <div class="form-field">


### PR DESCRIPTION
This PR fixes a minor typographical error in the HTML template for the `Call` view.

Specifically, the change is:

```diff
-commiting
+committing
```