### PR TITLE
Improve format of names in notes and commitments

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -5,18 +5,10 @@ class NotesController < ApplicationController
     @call = Call.find(params[:call_id])
     @note = @call.notes.create(note_params)
 
-    CallNotesChannel.broadcast_to @call, serialized_note if @note.persisted?
+    BroadcastNewNoteJob.perform_now(@call, @note) if @note.persisted?
   end
 
   private
-
-  def serialized_note
-    {
-      body: @note.body,
-      author_id: @note.author_id,
-      author: current_user.full_name
-    }.as_json
-  end
 
   def note_params
     params.require(:note).permit(:body).merge(author: current_user)

--- a/app/javascript/controllers/call_notes_controller.js
+++ b/app/javascript/controllers/call_notes_controller.js
@@ -26,9 +26,9 @@ export default class extends Controller {
           // Called when the subscription has been terminated by the server
         },
 
-        received(message) {
-          if (message.author_id !== controller.currentUserId) {
-            controller.appendNewMessage(message);
+        received(data) {
+          if (data.author_id !== controller.currentUserId) {
+            controller.listTarget.insertAdjacentHTML("beforeend", data.html);
           }
         },
       }
@@ -37,17 +37,5 @@ export default class extends Controller {
 
   disconnect() {
     this.subscription.unsubscribe();
-  }
-
-  appendNewMessage(message) {
-    const newMessageNode = document.createElement("div");
-    newMessageNode.className = "list-item";
-
-    const textNode = document.createTextNode(
-      `${message.author} ${message.body}`
-    );
-    newMessageNode.appendChild(textNode);
-
-    this.listTarget.appendChild(newMessageNode);
   }
 }

--- a/app/jobs/broadcast_new_note_job.rb
+++ b/app/jobs/broadcast_new_note_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class BroadcastNewNoteJob < ApplicationJob
+  def perform(call, note)
+    ActionCable.server.broadcast "call_notes:#{call.to_gid_param}",
+                                 broadcast_params(note)
+  end
+
+  def broadcast_params(note)
+    { author_id: note.author_id, html: render_new_note(note) }
+  end
+
+  def render_new_note(note)
+    ApplicationController
+      .render(
+        partial: "calls/note",
+        locals: { note: note }
+      )
+  end
+end

--- a/app/views/calls/_commitment_body.html.erb
+++ b/app/views/calls/_commitment_body.html.erb
@@ -1,3 +1,3 @@
 <div class="text">
-  <strong><%= commitment.user.first_name %>:</strong>&nbsp;<%= commitment.body %>
+  <b><%= commitment.user.first_name %>:</b>&nbsp;<%= commitment.body %>
 </div>

--- a/app/views/calls/_commitment_body.html.erb
+++ b/app/views/calls/_commitment_body.html.erb
@@ -1,4 +1,3 @@
 <div class="text">
-  <%= commitment.user.first_name %>
-  <%= commitment.body %>
+  <strong><%= commitment.user.first_name %>:</strong>&nbsp;<%= commitment.body %>
 </div>

--- a/app/views/calls/_note.html.erb
+++ b/app/views/calls/_note.html.erb
@@ -1,4 +1,3 @@
 <div class="list-item">
-  <%= note.author.full_name %>
-  <%= note.body %>
+  <strong><%= note.author.first_name %>:</strong>&nbsp;<%= note.body %>
 </div>

--- a/app/views/calls/_note.html.erb
+++ b/app/views/calls/_note.html.erb
@@ -1,3 +1,3 @@
 <div class="list-item">
-  <strong><%= note.author.first_name %>:</strong>&nbsp;<%= note.body %>
+  <b><%= note.author.first_name %>:</b>&nbsp;<%= note.body %>
 </div>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ApplicationController do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,11 +11,3 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end
-
-shared_context "user in an active call" do
-  before do
-    user = create(:user, :with_group)
-    call = create(:call, group: user.groups.first)
-    visit call_path(call, as: user)
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,3 +11,11 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end
+
+shared_context "user in an active call" do
+  before do
+    user = create(:user, :with_group)
+    call = create(:call, group: user.groups.first)
+    visit call_path(call, as: user)
+  end
+end

--- a/spec/system/user_creates_note_spec.rb
+++ b/spec/system/user_creates_note_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "user creates a note", js: true do
+  context "when the current user creates a note" do
+    include_context "user in an active call"
+
+    describe "creating a new note" do
+      it "formats the user's first name, a colon, and then their note" do
+        fill_in "note_body", with: "this is my note"
+        click_on "Create Note"
+        expect(page).to have_content /Elon:\s+this is my note/
+      end
+    end
+  end
+end

--- a/spec/system/user_creates_note_spec.rb
+++ b/spec/system/user_creates_note_spec.rb
@@ -2,16 +2,19 @@
 
 require "rails_helper"
 
-RSpec.describe "user creates a note", js: true do
-  context "when the current user creates a note" do
-    include_context "user in an active call"
+RSpec.describe "User creates a note", js: true do
+  context "when the user successfully creates note" do
+    it "display the user's first name, a colon, and then their note" do
+      user = create(:user, :with_group)
+      call = create(:call, group: user.groups.first)
+      note_body = "this is my note"
 
-    describe "creating a new note" do
-      it "formats the user's first name, a colon, and then their note" do
-        fill_in "note_body", with: "this is my note"
-        click_on "Create Note"
-        expect(page).to have_content /Elon:\s+this is my note/
-      end
+      visit call_path(call, as: user)
+      fill_in "note_body", with: note_body
+      click_on "Create Note"
+
+      expect(page).to have_content("#{user.first_name}:")
+      expect(page).to have_content(note_body)
     end
   end
 end


### PR DESCRIPTION
## This PR

- Closes #10 
- Improves the formatting of user names when displaying notes and commitments. Specifically, it displays only the user's first name, and in bold, followed by a colon (`:`). This improves the readability of the commitments and notes when viewing a call page.
- Adds a relevant unit test to ensure that the name formatting is the user's first name, followed by a colon, whitespace, and then their note.
- Adds a `shared_context` block for readability and future code re-use.
