### PR TITLE
Properly show email field on group form

### DIFF
--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -16,7 +16,7 @@
       </div>
     </div>
 
-    <% if action_name == "new" %>
+    <% if !@group.persisted? %>
       <div class="form-field">
         <%= label_tag :emails %>
         <%= text_field_tag :emails %>

--- a/spec/system/user_creates_a_group_spec.rb
+++ b/spec/system/user_creates_a_group_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe "User creates a group", js: true do
     expect(page).to have_content group_name
   end
 
+  it "shows the email field after an invalid submission" do
+    user = create(:user)
+    visit new_group_path(as: user)
+
+    fill_in "Name", with: ""
+    click_on "Create Group"
+
+    expect(page).to have_selector "#emails"
+  end
+
   it "assigns them as the facilitator" do
     user = create(:user)
     group_name = "New Group"

--- a/spec/system/user_edits_a_group_spec.rb
+++ b/spec/system/user_edits_a_group_spec.rb
@@ -4,6 +4,15 @@ require "rails_helper"
 
 RSpec.describe "User visits edit group page" do
   context "as the group owner" do
+    it "doesn't see the emails field" do
+      user = create(:user, :with_group)
+      group = user.groups.first
+
+      visit edit_group_path(group, as: user)
+
+      expect(page).to_not have_selector "#emails"
+    end
+
     context "clicks the trashcan link" do
       it "removes the group from their list" do
         user = create(:user, :with_group)


### PR DESCRIPTION
This PR fixes an issue where the email field would be hidden after
submitting the group form with invalid values. On page reload, the email
field would no longer be rendered.