### PR TITLE
Manage group invites

### DIFF
--- a/app/controllers/groups/group_invites_controller.rb
+++ b/app/controllers/groups/group_invites_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Groups
+  class GroupInvitesController < ApplicationController
+    def index
+      @group = Group.find(params[:group_id])
+      @group_invites = @group.group_invites
+    end
+
+    def create
+      group = Group.find(params[:group_id])
+
+      emails.each do |email|
+        GroupInviter.perform(email, group, current_user)
+      end
+
+      redirect_to group_group_invites_path group
+    end
+
+    def destroy
+      @group_invite = GroupInvite.find(params[:id])
+
+      @group_invite.destroy
+      redirect_to group_group_invites_path @group_invite.group
+    end
+
+    private
+
+    def emails
+      params[:emails].split(", ").map(&:strip)
+    end
+  end
+end

--- a/app/views/groups/group_invites/index.html.erb
+++ b/app/views/groups/group_invites/index.html.erb
@@ -1,0 +1,21 @@
+<div class="centered-content column">
+  <h2>Send new invites</h2>
+  <%= form_with url: group_group_invites_path(@group) do |form|  %>
+    <p> Add emails separated by commas:</p>
+    <%= form.text_field :emails %>
+    <%= form.submit "Send Invites" %>
+  <% end %>
+</div>
+<div class="centered-content column">
+  <h2>Pending invites</h2>
+  <div class="primary-list">
+    <% @group_invites.each do |invite| %>
+      <div class="list-item">
+        <%= invite.email %>
+        <%= link_to "Retract",
+          group_group_invite_path(invite.group, invite),
+          method: :delete %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/groups/group_invites/index.html.erb
+++ b/app/views/groups/group_invites/index.html.erb
@@ -12,7 +12,7 @@
     <% @group_invites.each do |invite| %>
       <div class="list-item">
         <%= invite.email %>
-        <%= link_to "Retract",
+        <%= link_to "Rescind",
           group_group_invite_path(invite.group, invite),
           method: :delete %>
       </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -9,6 +9,9 @@
     <%= link_to "Edit #{@group.name}", edit_group_path(@group) %>
   </div>
   <div class="top-link">
+    <%= link_to "Manage Invites", group_group_invites_path(@group) %>
+  </div>
+  <div class="top-link">
     Created by: <%= @group.creator.full_name %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,13 +15,18 @@ Rails.application.routes.draw do
     resource :timer, only: :create
   end
 
-  resources :groups
+  resources :groups do
+    scope module: :groups do
+      resources :group_invites, only: [:index, :create, :destroy]
+    end
+  end
 
-  resources :group_invites do
+  resources :group_invites, only: :index do
     member do
       post 'accept'
       post 'reject'
     end
   end
+
   resources :users, only: :create
 end

--- a/spec/system/user_manages_group_invites_spec.rb
+++ b/spec/system/user_manages_group_invites_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe "User manages group invites" do
     end
   end
 
-  it "retracts outstanding group invites" do
+  it "rescinds outstanding group invites" do
     user = create(:user, :with_group)
     group = user.groups.first
     invite = create(:group_invite, group: group)
 
     visit group_group_invites_path(group, as: user)
-    click_on "Retract"
+    click_on "Rescind"
 
     expect(page.current_path).to eq group_group_invites_path(group)
     expect(page).to_not have_content(invite)

--- a/spec/system/user_manages_group_invites_spec.rb
+++ b/spec/system/user_manages_group_invites_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "User manages group invites" do
+  it "views outstanding group invites" do
+    user = create(:user, :with_group)
+    group = user.groups.first
+    group_invites = create_list(:group_invite, 3, group: group)
+
+    visit group_group_invites_path(group, as: user)
+
+    group_invites.each do |invite|
+      expect(page).to have_content invite.email
+    end
+  end
+
+  it "retracts outstanding group invites" do
+    user = create(:user, :with_group)
+    group = user.groups.first
+    invite = create(:group_invite, group: group)
+
+    visit group_group_invites_path(group, as: user)
+    click_on "Retract"
+
+    expect(page.current_path).to eq group_group_invites_path(group)
+    expect(page).to_not have_content(invite)
+  end
+
+  it "creates new invites" do
+    user = create(:user, :with_group)
+    group = user.groups.first
+
+    email1 = "newuser@example.com"
+    email2 = "anotheruser@example.com"
+
+    visit group_group_invites_path(group, as: user)
+    fill_in "emails", with: "#{email1}, #{email2}"
+    click_on "Send Invites"
+
+    expect(page.current_path).to eq group_group_invites_path(group)
+    expect(GroupInvite.count).to eq 2
+    expect(page).to have_content email1
+    expect(page).to have_content email2
+  end
+
+  it "sends emails to new invitees" do
+    user = create(:user, :with_group)
+    group = user.groups.first
+
+    email1 = "newuser@example.com"
+    email2 = "anotheruser@example.com"
+
+    visit group_group_invites_path(group, as: user)
+    fill_in "emails", with: "#{email1}, #{email2}"
+    expect { click_on "Send Invites" }
+      .to change { ActionMailer::Base.deliveries.count }.by 2
+  end
+end


### PR DESCRIPTION
This PR adds some basic features to allow users to manage invites for
their groups. Users can now retract pending invites and send out new
invites.

Co-authored-by: Eric Hanko <eric.hanko1@gmail.com>