### PR TITLE
Group creators can view and remove group members

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,11 +1,9 @@
+# frozen_string_literal: true
+
 class MembershipsController < ApplicationController
   def destroy
     membership = Membership.find(params[:id])
-
-    unless current_user == membership.user
-      membership.destroy
-    end
-
+    membership.destroy unless current_user == membership.user
     redirect_to edit_group_path membership.group
   end
 end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,0 +1,11 @@
+class MembershipsController < ApplicationController
+  def destroy
+    membership = Membership.find(params[:id])
+
+    unless current_user == membership.user
+      membership.destroy
+    end
+
+    redirect_to edit_group_path membership.group
+  end
+end

--- a/app/views/groups/_memberships.html.erb
+++ b/app/views/groups/_memberships.html.erb
@@ -1,0 +1,20 @@
+<div id="group_members">
+  <h2>Members</h2>
+  <form class="primary-list">
+    <% memberships.each do |membership| %>
+      <div class="list-item space-between">
+        <div><%= membership.user.full_name %></div>
+        <div>
+          <% unless current_user == membership.user %>
+            <%= link_to group_membership_path(membership.group, membership),
+              id: "delete_member_#{membership.id}",
+              method: :delete,
+              data: { confirm: "Are you sure you want to remove this member? This is permanent." } do %>
+              <%= octicon "trashcan", class: "red", height: 15 %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </form>
+</div>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,4 +1,24 @@
 <div class="centered-form">
   <h2>Edit <%= @group.name %></h2>
   <%= render "form" %>
+  <div id="group_members">
+    <h2>Members</h2>
+    <form class="primary-list">
+      <% @group.memberships.each do |membership| %>
+        <div class="list-item space-between">
+          <div><%= membership.user.full_name %></div>
+          <div>
+            <% unless current_user == membership.user %>
+              <%= link_to group_membership_path(@group, membership),
+                id: "delete_member_#{membership.id}",
+                method: :delete,
+                data: { confirm: "Are you sure you want to remove this member? This is permanent." } do %>
+                <%= octicon "trashcan", class: "red", height: 15 %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </form>
+  </div>
 </div>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,24 +1,5 @@
 <div class="centered-form">
   <h2>Edit <%= @group.name %></h2>
   <%= render "form" %>
-  <div id="group_members">
-    <h2>Members</h2>
-    <form class="primary-list">
-      <% @group.memberships.each do |membership| %>
-        <div class="list-item space-between">
-          <div><%= membership.user.full_name %></div>
-          <div>
-            <% unless current_user == membership.user %>
-              <%= link_to group_membership_path(@group, membership),
-                id: "delete_member_#{membership.id}",
-                method: :delete,
-                data: { confirm: "Are you sure you want to remove this member? This is permanent." } do %>
-                <%= octicon "trashcan", class: "red", height: 15 %>
-              <% end %>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-    </form>
-  </div>
+  <%= render "memberships", memberships: @group.memberships %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
     resource :timer, only: :create
   end
 
-  resources :groups
+  resources :groups do
+    resources :memberships, only: :destroy
+  end
 
   resources :group_invites do
     member do

--- a/spec/system/user_edits_a_group_spec.rb
+++ b/spec/system/user_edits_a_group_spec.rb
@@ -44,6 +44,63 @@ RSpec.describe "User visits edit group page" do
         expect(Timer.count).to be_zero
       end
     end
+
+    it "lists the existing members" do
+      user = create(:user, :with_group)
+      group = user.groups.first
+      member = create(
+        :membership,
+        group: group,
+        user: create(:user)
+      )
+      other_member = create(
+        :membership,
+        group: group,
+        user: create(:user)
+      )
+
+      visit edit_group_path(group, as: user)
+
+      expect(page).to have_content user.full_name
+      expect(page).to have_content member.user.full_name
+      expect(page).to have_content other_member.user.full_name
+    end
+
+    it "removes a member from the group" do
+      user = create(:user, :with_group)
+      group = user.groups.first
+      member = create(
+        :membership,
+        group: group,
+        user: create(:user, first_name: "delete")
+      )
+      other_member = create(
+        :membership,
+        group: group,
+        user: create(:user, first_name: "keep")
+      )
+
+      visit edit_group_path(group, as: user)
+
+      within "#group_members" do
+        click_on :"delete_member_#{member.id}"
+      end
+
+      expect(page).to_not have_content member.user.full_name
+      expect(page).to have_content other_member.user.full_name
+    end
+
+    it "prevents a user from deleting their own membership" do
+      membership = create(:membership)
+
+      delete group_membership_path(
+        membership.group,
+        membership,
+        as: membership.user
+      )
+
+      expect(Membership.find(membership.id)).to be_present
+    end
   end
 
   context "when the user is not the group owner" do


### PR DESCRIPTION
This PR adds some basic functionality around managing group membership.

A new route and controller were introduced used for deleting group
memberships. Users are prevented from removing their own membership

Co-authored-by: Kurt Galiatsatos <soad1789@gmail.com>