### PR TITLE
Add edit page for user profile

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < Clearance::UsersController
 
   def update
     if current_user.update(user_params)
+      flash[:notice] = "Profile updated"
       redirect_to user_path
     else
       render :edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
 class UsersController < Clearance::UsersController
-  before_action :require_login, only: :show
+  before_action :require_login, only: [:show, :edit]
 
   def show; end
+
+  def edit
+    @user = current_user
+  end
+
+  def update
+    if current_user.update(user_params)
+      redirect_to user_path
+    else
+      render :edit
+    end
+  end
 
   def create
     @user = User.new(user_params)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,6 +30,6 @@ class UsersController < Clearance::UsersController
   private
 
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :email, :password)
+    params.require(:user).permit(:first_name, :last_name, :email, :password, :receive_reminder_email)
   end
 end

--- a/app/mailers/commitment_reminder_mailer.rb
+++ b/app/mailers/commitment_reminder_mailer.rb
@@ -4,7 +4,7 @@ class CommitmentReminderMailer < ApplicationMailer
   def post_call_reminder(call)
     @call = call
     build_commitment_summaries
-    mail(to: recipients,
+    mail(to: user_emails,
          subject: "Commitments This Week",
          template_name: "reminder")
   end
@@ -12,7 +12,7 @@ class CommitmentReminderMailer < ApplicationMailer
   def mid_week_reminder(call)
     @call = call
     build_commitment_summaries
-    mail(to: recipients,
+    mail(to: user_emails,
          subject: "How's this week's commitment going?",
          template_name: "reminder")
   end
@@ -20,12 +20,15 @@ class CommitmentReminderMailer < ApplicationMailer
   private
 
   def build_commitment_summaries
-    @user_commitment_summaries = @call
-      .users
+    @user_commitment_summaries = call_users
       .map { |user| UserCommitmentSummary.new(user, @call) }
   end
 
-  def recipients
-    @call.users.map(&:email)
+  def user_emails
+    call_users.map(&:email)
+  end
+
+  def call_users
+    @call.users.receives_reminders
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
   has_many :groups, through: :memberships
   has_many :created_groups, class_name: "Group", foreign_key: :creator_id
 
+  scope :receives_reminders, -> { where(receive_reminder_email: true) }
+
   def full_name
     "#{first_name} #{last_name}"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@
 class User < ApplicationRecord
   include Clearance::User
 
+  validates :first_name, :last_name, presence: true
+
   has_many :memberships
   has_many :commitments, through: :memberships
   has_many :groups, through: :memberships

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,9 @@
       </div>
     <% end %>
     <div class="main-content">
+      <% if flash[:notice] %>
+        <div class="notice"><%= flash[:notice] %></div>
+      <% end %>
       <%= yield %>
     </div>
   </body>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,35 @@
+<div class="sign-up" id="clearance">
+  <h2>Edit Profile</h2>
+
+  <% if current_user.errors.present? %>
+    <div class="errors">
+      Please fill out all fields
+    </div>
+  <% end %>
+
+
+  <div class="form">
+    <%= form_for current_user, url: user_path, method: "put" do |form| %>
+
+      <div class="form-field">
+        <%= form.label :first_name %>
+        <%= form.text_field :first_name %>
+      </div>
+
+      <div class="form-field">
+        <%= form.label :last_name %>
+        <%= form.text_field :last_name %>
+      </div>
+
+      <div class="form-field">
+        <%= form.label :email %>
+        <%= form.text_field :email %>
+      </div>
+
+      <div class="form-field">
+        <%= form.submit %>
+      </div>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -27,6 +27,11 @@
       </div>
 
       <div class="form-field">
+        <%= form.label :receive_reminder_email %>
+        <%= form.check_box :receive_reminder_email %>
+      </div>
+
+      <div class="form-field">
         <%= form.submit %>
       </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,5 +4,8 @@
     <div class="card-content">
       <div class="list-item"><%= current_user.email %></div>
     </div>
+    <div class="card-footer">
+      <%= link_to "Edit Profile", edit_user_path %>
+    </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,6 +3,11 @@
     <div class="card-title"><%= current_user.full_name %></div>
     <div class="card-content">
       <div class="list-item"><%= current_user.email %></div>
+      <% if current_user.receive_reminder_email %>
+        <div class="list-item">Subscribed to reminder emails</div>
+      <% else %>
+        <div class="list-item">Not subscribed to reminder emails</div>
+      <% end %>
     </div>
     <div class="card-footer">
       <%= link_to "Edit Profile", edit_user_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,6 @@ Rails.application.routes.draw do
     end
   end
 
-  resource :user, only: :show
+  resource :user, only: [:edit, :update, :show]
   resources :users, only: [:create]
 end

--- a/db/migrate/20201128221225_add_receive_reminder_email_to_users.rb
+++ b/db/migrate/20201128221225_add_receive_reminder_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddReceiveReminderEmailToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :receive_reminder_email, :boolean, null: false, index: true, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_05_132222) do
+ActiveRecord::Schema.define(version: 2020_11_28_221225) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 2020_09_05_132222) do
     t.string "first_name", null: false
     t.string "last_name", null: false
     t.string "role", default: "member", null: false
+    t.boolean "receive_reminder_email", default: true, null: false
     t.index ["email"], name: "index_users_on_email"
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end

--- a/spec/mailers/commit_reminder_mailer_spec.rb
+++ b/spec/mailers/commit_reminder_mailer_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe CommitmentReminderMailer do
 
       expect(mailer.to).to eq [user.email]
     end
+
+    it "doesn't send to users who are unsubscribed from reminders" do
+      group = create(:group)
+      subscribed_user = create(:user, receive_reminder_email: true)
+      unsubscribed_user = create(:user, receive_reminder_email: false)
+      group.users << [subscribed_user, unsubscribed_user]
+      call = create(:call, group: group)
+
+      mailer = CommitmentReminderMailer.post_call_reminder(call)
+
+      expect(mailer.to).to eq [subscribed_user.email]
+    end
   end
 
   describe ".mid_week_reminder" do
@@ -22,6 +34,18 @@ RSpec.describe CommitmentReminderMailer do
       mailer = CommitmentReminderMailer.mid_week_reminder(call)
 
       expect(mailer.to).to eq [user.email]
+    end
+
+    it "doesn't send to users who are unsubscribed from reminders" do
+      group = create(:group)
+      subscribed_user = create(:user, receive_reminder_email: true)
+      unsubscribed_user = create(:user, receive_reminder_email: false)
+      group.users << [subscribed_user, unsubscribed_user]
+      call = create(:call, group: group)
+
+      mailer = CommitmentReminderMailer.mid_week_reminder(call)
+
+      expect(mailer.to).to eq [subscribed_user.email]
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe User do
+  describe "validations" do
+    it { should validate_presence_of(:first_name) }
+    it { should validate_presence_of(:last_name) }
+  end
+end

--- a/spec/system/user_edits_profile_spec.rb
+++ b/spec/system/user_edits_profile_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "User edits their profile" do
+  context "as a signed in user" do
+    it "updates their profile" do
+      user = create(:user)
+      first_name = "new"
+      last_name = "name"
+      email = "new@example.com"
+
+      visit edit_user_path(as: user)
+      fill_in :user_first_name, with: first_name
+      fill_in :user_last_name, with: last_name
+      fill_in :user_email, with: email
+      click_on "Update User"
+
+      user.reload
+
+      expect(user.first_name).to eq first_name
+      expect(user.last_name).to eq last_name
+      expect(user.email).to eq email
+    end
+  end
+
+  context "without an authenticated session" do
+    it "redirects to the sign in page" do
+      visit edit_user_path
+
+      expect(current_path).to eq sign_in_path
+    end
+  end
+end

--- a/spec/system/user_edits_profile_spec.rb
+++ b/spec/system/user_edits_profile_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "User edits their profile" do
   context "as a signed in user" do
     it "updates their profile" do
-      user = create(:user)
+      user = create(:user, receive_reminder_email: false)
       first_name = "new"
       last_name = "name"
       email = "new@example.com"
@@ -14,6 +14,7 @@ RSpec.describe "User edits their profile" do
       fill_in :user_first_name, with: first_name
       fill_in :user_last_name, with: last_name
       fill_in :user_email, with: email
+      check :user_receive_reminder_email
       click_on "Update User"
 
       user.reload
@@ -21,6 +22,7 @@ RSpec.describe "User edits their profile" do
       expect(user.first_name).to eq first_name
       expect(user.last_name).to eq last_name
       expect(user.email).to eq email
+      expect(user.receive_reminder_email).to be true
     end
   end
 


### PR DESCRIPTION
This adds a basic edit profile page. First, last and email can be
edited. Passwords can't be updated from this page yet.