### PR TITLE
Add basic styling to user profile page

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1,3 +1,7 @@
+.title-large {
+  font-size: 36px;
+}
+
 .title {
   font-size: 24px;
 }
@@ -22,7 +26,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-
 }
 
 .avatar {
@@ -35,8 +38,26 @@
   border-radius: 100%;
   height: 40px;
   width: 40px;
+
+  &.avatar-large {
+    height: 250px;
+    width: 250px;
+  }
 }
 
 .top-link {
   margin: 10px;
 }
+
+.profile-content {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+}
+
+.profile-content > {
+  * {
+    margin-bottom: 30px;
+  }
+}
+

--- a/app/renderers/user_avatar.rb
+++ b/app/renderers/user_avatar.rb
@@ -6,16 +6,17 @@ class UserAvatar
 
   class SizeNotDefined < StandardError; end
 
-  AVATAR_SIZES = [:small, :large].freeze
-  LARGE_SIZE = 250
+  SIZES = [:small, :large].freeze
+  LARGE_PIXEL_SIZE = 250
 
   AVATAR_PROPS = {
     small: OpenStruct.new(css_class: nil, gravatar_size: nil),
-    large: OpenStruct.new(css_class: " avatar-large", gravatar_size: LARGE_SIZE)
+    large: OpenStruct.new(css_class: " avatar-large",
+                          gravatar_size: LARGE_PIXEL_SIZE)
   }.freeze
 
   def initialize(user, size)
-    unless AVATAR_SIZES.include?(size)
+    unless SIZES.include?(size)
       raise SizeNotDefined, "Size must be included in AVATAR_SIZES"
     end
 

--- a/app/renderers/user_avatar.rb
+++ b/app/renderers/user_avatar.rb
@@ -4,32 +4,52 @@ class UserAvatar
   include ActionView::Helpers::AssetTagHelper
   include ActionView::Helpers::TagHelper
 
-  def initialize(user)
+  class SizeNotDefined < StandardError; end
+
+  AVATAR_SIZES = [:small, :large].freeze
+  LARGE_SIZE = 250
+
+  AVATAR_PROPS = {
+    small: OpenStruct.new(css_class: nil, gravatar_size: nil),
+    large: OpenStruct.new(css_class: " avatar-large", gravatar_size: LARGE_SIZE)
+  }.freeze
+
+  def initialize(user, size)
+    unless AVATAR_SIZES.include?(size)
+      raise SizeNotDefined, "Size must be included in AVATAR_SIZES"
+    end
+
     @user = user
+    @avatar_props = AVATAR_PROPS[size]
   end
 
-  def self.render(user)
-    new(user).render
+  def self.render(user, size: :small)
+    new(user, size).render
   end
 
   def render
     if user_has_gravatar?
-      image_tag(image_src, class: "avatar")
+      image_tag(image_src, class: "avatar#{avatar_props.css_class}")
     else
-      content_tag(:div, user.initials, class: "avatar")
+      content_tag(:div, user.initials,
+                  class: "avatar#{avatar_props.css_class}")
     end
   end
 
   private
 
-  attr_reader :user
+  attr_reader :avatar_props, :user
 
   def email_hash
     Digest::MD5.hexdigest(user.email)
   end
 
   def image_src
-    "https://www.gravatar.com/avatar/#{email_hash}"
+    "https://www.gravatar.com/avatar/#{email_hash}#{size_param}"
+  end
+
+  def size_param
+    "?s=#{avatar_props.gravatar_size}" unless avatar_props.gravatar_size.nil?
   end
 
   def user_has_gravatar?

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,16 +1,19 @@
 <div class="centered-content">
-  <div class="card card-large">
-    <div class="card-title"><%= current_user.full_name %></div>
-    <div class="card-content">
-      <div class="list-item"><%= current_user.email %></div>
-      <% if current_user.receive_reminder_email %>
-        <div class="list-item">Subscribed to reminder emails</div>
-      <% else %>
-        <div class="list-item">Not subscribed to reminder emails</div>
+  <div class="profile-content">
+    <div class="title-large">
+      <%= current_user.full_name %>
+      <%= link_to edit_user_path do %>
+        <%= octicon "pencil", height: 24 %>
       <% end %>
     </div>
-    <div class="card-footer">
-      <%= link_to "Edit Profile", edit_user_path %>
-    </div>
+
+    <%= UserAvatar.render(current_user, size: :large) %>
+
+    <div class="subtitle">Email: <%= current_user.email %></div>
+    <% if current_user.receive_reminder_email %>
+      <div class="subtitle">You are subscribed to reminder emails</div>
+    <% else %>
+      <div class="subtitle">You are not subscribed to reminder emails</div>
+    <% end %>
   </div>
 </div>

--- a/spec/renderers/user_avatar_spec.rb
+++ b/spec/renderers/user_avatar_spec.rb
@@ -3,27 +3,95 @@
 require "rails_helper"
 
 RSpec.describe UserAvatar do
-  describe "render" do
+  describe ".new" do
+    it "raises if the given size is not defined in AVATAR_SIZES" do
+      user = build(:user)
+
+      expect { UserAvatar.new(user, size: "bananas") }
+        .to raise_error UserAvatar::SizeNotDefined
+    end
+  end
+
+  describe ".render" do
     context "when the user has a gravatar" do
       it "renders an image with the gravatar src" do
-        response = Net::HTTPSuccess.new("1.1", 200, "")
-        allow(Net::HTTP).to receive(:get_response).and_return(response)
+        stub_http_request success_response
+        user = build(:user)
+        image_url = build_gravatar_url(user)
 
-        user = create(:user)
-        email_hash = Digest::MD5.hexdigest(user.email)
-        image_src = "https://www.gravatar.com/avatar/#{email_hash}"
+        result = UserAvatar.render(user)
 
-        expect(UserAvatar.render(user))
-          .to eq "<img class=\"avatar\" src=\"#{image_src}\" />"
-      end
-
-      it "renders the user's initials when the user doesn't have a gravatar" do
-        response = Net::HTTPNotFound.new("1.1", 404, "")
-        allow(Net::HTTP).to receive(:get_response).and_return(response)
-        user = create(:user)
-
-        expect(UserAvatar.render(user)).to eq "<div class=\"avatar\">EM</div>"
+        expect(result).to eq "<img class=\"avatar\" src=\"#{image_url}\" />"
       end
     end
+
+    it "renders the user's initials when the user doesn't have a gravatar" do
+      stub_http_request error_response
+      user = build(:user)
+
+      result = UserAvatar.render(user)
+
+      expect(result).to eq "<div class=\"avatar\">EM</div>"
+    end
+
+    context "when the size is small" do
+      it "uses 'avatar' class" do
+        response = Net::HTTPSuccess.new("1.1", 200, "")
+        stub_http_request(response)
+        user = build(:user)
+
+        result = UserAvatar.render(user, size: :small)
+
+        expect(result).to include "class=\"avatar\""
+      end
+
+      it "doesn't add a size query param to the image source" do
+        stub_http_request success_response
+        user = build(:user)
+
+        result = UserAvatar.render(user, size: :small)
+
+        expect(result).to_not include "?s="
+      end
+    end
+
+    context "when the size is large" do
+      it "uses 'avatar-large' class" do
+        stub_http_request success_response
+        user = build(:user)
+
+        user_avatar = UserAvatar.render(user, size: :large)
+
+        expect(user_avatar).to include "class=\"avatar avatar-large\""
+      end
+
+      it "adds a size query param image source" do
+        stub_http_request success_response
+        user = build(:user)
+        image_url = build_gravatar_url(user)
+        gravatar_size = UserAvatar::LARGE_SIZE
+
+        result = UserAvatar.render(user, size: :large)
+
+        expect(result).to include "src=\"#{image_url}?s=#{gravatar_size}\""
+      end
+    end
+  end
+
+  def stub_http_request(response)
+    allow(Net::HTTP).to receive(:get_response).and_return(response)
+  end
+
+  def build_gravatar_url(user)
+    email_hash = Digest::MD5.hexdigest(user.email)
+    "https://www.gravatar.com/avatar/#{email_hash}"
+  end
+
+  def success_response
+    Net::HTTPSuccess.new("1.1", 200, "")
+  end
+
+  def error_response
+    Net::HTTPNotFound.new("1.1", 404, "")
   end
 end

--- a/spec/renderers/user_avatar_spec.rb
+++ b/spec/renderers/user_avatar_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe UserAvatar do
         stub_http_request success_response
         user = build(:user)
         image_url = build_gravatar_url(user)
-        gravatar_size = UserAvatar::LARGE_SIZE
+        gravatar_size = UserAvatar::LARGE_PIXEL_SIZE
 
         result = UserAvatar.render(user, size: :large)
 


### PR DESCRIPTION
This commit adds some nicer styling to the user profile page, including
adding the user's avatar to the page.

We also refactored the `UserAvatar` class to accept a size argument so a
larger-size image can be used where desired. These changes include some
clean up of the tests for the `UserAvatar` class.

<img width="960" alt="Screen Shot 2020-12-08 at 11 04 57 AM" src="https://user-images.githubusercontent.com/11845816/101508177-59612f00-3945-11eb-9aaa-061cc87e2826.png">

Co-authored-by: Kurt G. <soad1789@gmail.com>